### PR TITLE
Add dynamic RSS feeds

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 CHANGES
 =======
 
+* Add dynamic RSS feeds
 * Fix random test pass/fail result
 * Add some tests from sheer to sheerlike
 * git ignore fix via @kurtw

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ elasticsearch==1.6.0
 Jinja2==2.7.3
 python-dateutil==2.4.2
 pytz
+feedparser==5.2.1
+mock==1.3.0

--- a/sheerlike/feeds.py
+++ b/sheerlike/feeds.py
@@ -1,0 +1,62 @@
+import os
+import json
+
+from django.contrib.syndication.views import Feed
+from django.http import Http404
+
+from sheerlike.query import QueryFinder
+
+PARAM_TOKEN = '$$'
+
+
+class SheerlikeFeed(Feed):
+    doc_type = None
+
+    def title(self):
+        return self.settings.get('feed_title')
+
+    def link(self):
+        return self.settings.get('feed_url')
+
+    def items(self, obj):
+        return obj.search()
+
+    def item_link(self, item):
+        return self.get_field_value(item, 'entry_url')
+
+    def item_title(self, item):
+        return self.get_field_value(item, 'entry_title')
+
+    def item_description(self, item):
+        return self.get_field_value(item, 'entry_content')
+
+    def item_author_name(self, item):
+        author = self.get_field_value(item, 'entry_author')
+        return author[0] if isinstance(author, list) else author
+
+    def item_updateddate(self, item):
+        return self.get_field_value(item, 'entry_updated')
+
+    def get_object(self, request, *args, **kwargs):
+        if kwargs.get('doc_type'):
+            self.doc_type = kwargs.get('doc_type')
+        query_finder = QueryFinder()
+        query = getattr(query_finder, self.doc_type)
+        if not query:
+            raise Http404
+        self.settings_file = query.filename
+        self.settings = self.get_settings()
+        return query
+
+    def get_field_value(self, item, param):
+        setting = self.settings.get(param)
+        if setting:
+            return getattr(item, setting.replace(PARAM_TOKEN, ''))
+
+    def get_settings(self):
+        if os.path.isfile(self.settings_file):
+            with open(self.settings_file) as json_file:
+                data = json.load(json_file)
+                return data.get('feed')
+        else:
+            raise Exception('Unable to find feed settings file')

--- a/sheerlike/test_feeds.py
+++ b/sheerlike/test_feeds.py
@@ -1,0 +1,63 @@
+import datetime
+
+import mock
+import feedparser
+from django.test import TestCase
+from django.test.client import RequestFactory
+
+from sheerlike.feeds import SheerlikeFeed
+
+
+class FakeESItem(object):
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class TestRSSFeed(TestCase):
+
+    @mock.patch('sheerlike.query.QueryResults')
+    @mock.patch('sheerlike.feeds.QueryFinder')
+    def test_successful_feed(self, mock_QueryFinder, mock_QueryResults):
+        with mock.patch.object(SheerlikeFeed, 'get_settings') as mock_get_settings:
+            with mock.patch.object(SheerlikeFeed, 'items') as mock_items:
+                # Create some fake settings
+                mock_get_settings.return_value = {"feed_title": "Test Feed",
+                                                  "feed_url": "/test-url/",
+                                                  "entry_title": "$$title$$",
+                                                  "entry_author": "$$author$$",
+                                                  "entry_content": "$$content$$",
+                                                  "entry_summary": "$$excerpt$$",
+                                                  "entry_url": "$$url$$",
+                                                  "entry_updated": "$$modified$$"
+                                                  }
+                # Create some fake items to populate the feed
+                fake_es_item_1 = FakeESItem(title='Hi, Sup',
+                                            content='some content',
+                                            url='/hi-sup/',
+                                            author='Dan',
+                                            modified=datetime.datetime.now())
+                fake_es_item_2 = FakeESItem(title='Another Fine Title',
+                                            content='interesting content',
+                                            url='/another-fine-title/',
+                                            author='Kurt',
+                                            modified=datetime.datetime.now())
+                # Ensure these are returned when SheerlikeFeed.items() is called
+                mock_items.return_value = [fake_es_item_1, fake_es_item_2]
+                self.feed = SheerlikeFeed()
+                self.feed.doc_type = 'test'
+                # In order to grab the feed results, we need to pass it a fake
+                # request object
+                rf = RequestFactory()
+                get_request = rf.get('/feed/test-url/')
+                f = feedparser.parse(self.feed.__call__(get_request).content)
+                feed = f.feed
+                entries = f.entries
+                assert len(entries) == 2
+                assert feed.title == 'Test Feed'
+                for entry in entries:
+                    if entry.author != 'Dan':
+                        continue
+                    assert entry.title == 'Hi, Sup'
+                    assert entry.summary == 'some content'
+                    assert entry.link == 'http://testserver/hi-sup/'


### PR DESCRIPTION
This adds dynamic RSS feeds to sheerlike.

It works seamlessly with how feeds worked in cfgov-refresh/sheer, so no changes are necessary to get this working other than adding the URL route to cfgov-django (separate PR will be opened).

An additional dependency was added for parsing the RSS feed for testing.

Review: @rosskarchner 
