### PR TITLE
Downgrade dateutil to be compatible with sheer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 unipath>=1.1,<=2.0
 elasticsearch==1.6.0
 Jinja2==2.7.3
-python-dateutil==2.4.2
+python-dateutil==2.1
 pytz
 feedparser==5.2.1
 mock==1.3.0


### PR DESCRIPTION
@rosskarchner we thought this made more sense to do in the short run since other teams (OaH) are sensitive to changes to sheer.

@kave
