### PR TITLE
Fix bug so string values actually convert to the correct timezone

### DIFF
--- a/sheerlike/__init__.py
+++ b/sheerlike/__init__.py
@@ -31,10 +31,6 @@ def url_for(app, filename):
     else:
         raise ValueError("url_for doesn't know about %s" % app)
 
-def date_filter(value, format="%Y-%m-%d", tz="America/New_York"):
-            return date_formatter(value, format, tz)
-
-
 class SheerlikeContext(Context):
     def __init__(self, environment, parent, name, blocks):
         super(SheerlikeContext, self).__init__(environment, parent, name, blocks)
@@ -96,6 +92,6 @@ def environment(**options):
         'when': when
     })
     env.filters.update({
-        'date': date_filter
+        'date': date_formatter
     })
     return env

--- a/sheerlike/templates.py
+++ b/sheerlike/templates.py
@@ -2,12 +2,11 @@ import datetime
 from dateutil import parser
 from pytz import timezone
 
+
 def date_formatter(value, format="%Y-%m-%d", tz='America/New_York'):
     if type(value) not in [datetime.datetime, datetime.date]:
-        date = parser.parse(value, default=datetime.datetime.today().replace(day=1))
-        naive = date.replace(tzinfo=None)
-        dt = timezone(tz).localize(naive)
-    else:
-        dt = value
+        value = parser.parse(value, default=datetime.datetime.today().replace(day=1))
+    naive = value.replace(tzinfo=None)
+    dt = timezone(tz).localize(naive)
 
     return dt.strftime(format)


### PR DESCRIPTION
String values aren't being converted to the correct timezone so they show up at UTC. This fixes that. It also replaces the use of a function that just returns the value of `date_formatter` with `date_formatter`.

@rosskarchner @kave
